### PR TITLE
fix: 修复 config 类型定义问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wangeditor-for-react",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Wangeditor component for React.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/type.ts
+++ b/src/type.ts
@@ -16,7 +16,7 @@ type hookType = Record<
 export type ReactWEProps = {
 	style?: StyleSheet;
 	className?: string;
-	config?: ConfigType;
+	config?: Partial<ConfigType>;
 
 	defaultValue?: string;
 	localBlobImg?: boolean;


### PR DESCRIPTION

## 问题描述

![image](https://user-images.githubusercontent.com/19297757/130072033-48c9df70-a73b-484b-b859-633134d05a6d.png)

如下图所示，当配置 config 属性时会类型错误。

## 错误原因

当配置 `config` 某一个属性时就会应用 `ConfigType` 类型定义，而 `ConfigType` 里的定义都是必选的，所以如果仅写一个配置项就会报错，必须全部都写。

## 解决方案

将 `ConfigType` 里的配置项转为可选，Typescript 提供了工具库 `Partial`，只需要 `Partial<ConfigType>`  就不会报错了。

![image](https://user-images.githubusercontent.com/19297757/130072640-1c53d437-2a89-4668-a605-727e89950242.png)

> 请合并一下请求，并发一下 npm 包


