### PR TITLE
fix: 修复类型应用问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "wangeditor-for-react",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Wangeditor component for React.",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:es": "babel es6 -d lib",

--- a/src/type.ts
+++ b/src/type.ts
@@ -4,9 +4,9 @@
  * @Date: 2021-07-02 10:49:27
  * @LastEditTime: 2021-07-05 16:04:57
  */
-import WEditor from 'wangeditor/src/editor';
-import { ConfigType } from 'wangeditor/src/config';
-import langConfig from 'wangeditor/src/config/lang';
+import { ConfigType } from 'wangeditor/dist/config';
+import langConfig from 'wangeditor/dist/config/lang';
+import WEditor from 'wangeditor/dist/editor';
 
 type hookType = Record<
 	string,


### PR DESCRIPTION

## 问题描述

当项目使用 `tsc --noEmit` 做类型检查时，会报大量的错误。

![image](https://user-images.githubusercontent.com/19297757/130315022-d51a3060-c809-4f87-b095-cd8bd23e2cc9.png)

并且在 `tsconfig.json` 中忽略 `node_modules`，`node_modules/wangeditor/**/*` 和 `skipLibCheck` 都于事无补、

![image](https://user-images.githubusercontent.com/19297757/130315066-8b8c36b9-adec-4a7e-8079-e24f2b27dce7.png)

## 原因

在 `src/type.ts` 中，类型引用了 `wangeditor` 源码的类型，进行了实质性编译，而非简单的类型应用，所以并不会被忽略。

## 解决方案

将 `wangeditor/src/xx` 修改成了 `wangeditor/dist/xx` 即可。同时，我发现咱们生成类型定义后，并没有在 `package.json` 中指明类型文件的配置 `types`，再次一并加上。


## 希望

希望能发个新版本，解决一下这个问题，多谢了~




